### PR TITLE
gradle improvements

### DIFF
--- a/android-driver/build.gradle
+++ b/android-driver/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.4.0-beta5'
+        classpath rootProject.ext.android_build_tools_gradle
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
     }
 }
@@ -12,8 +12,8 @@ apply plugin: 'android-sdk-manager'
 apply plugin: 'android'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 10

--- a/build.gradle
+++ b/build.gradle
@@ -2,5 +2,16 @@ allprojects {
     repositories {
         jcenter()
     }
+
     version = '0.18.0-SNAPSHOT'
+
+    ext {
+        // https://bintray.com/android/android-tools/com.android.tools.build.gradle/view
+        android_build_tools_gradle = 'com.android.tools.build:gradle:1.4.0-beta6'
+        // https://bintray.com/bintray/jcenter/org.seleniumhq.selenium%3Aselenium-java/
+        selenium_version = '2.48.2'
+        compileSdkVersion = 23
+        buildToolsVersion = '23.0.2'
+        junit = 'junit:junit:4.12'
+    }
 }

--- a/selendroid-client/build.gradle
+++ b/selendroid-client/build.gradle
@@ -2,6 +2,19 @@ apply plugin: 'java'
 
 dependencies {
     compile 'org.seleniumhq.selenium:selenium-java:2.48.2'
+    // see deps to exclude by visiting:
+    // https://bintray.com/bintray/jcenter/org.seleniumhq.selenium%3Aselenium-java/2.48.2/view#files
+    compile("org.seleniumhq.selenium:selenium-java:$rootProject.ext.selenium_version") {
+        exclude(module: 'selenium-chrome-driver')
+        exclude(module: 'selenium-edge-driver')
+        exclude(module: 'selenium-htmlunit-driver')
+        exclude(module: 'selenium-firefox-driver')
+        exclude(module: 'selenium-ie-driver')
+        exclude(module: 'selenium-safari-driver')
+        // exclude(module: 'selenium-support')
+        exclude(module: 'webbit')
+        exclude(module: 'selenium-leg-rc')
+    }
     compile project(':selendroid-common')
     compile project(':selendroid-server-common')
 }

--- a/selendroid-common/build.gradle
+++ b/selendroid-common/build.gradle
@@ -2,13 +2,18 @@ apply plugin: 'java'
 
 dependencies {
     compile 'org.json:json:20090211'
-    compile 'junit:junit:4.12'
-    compile('org.seleniumhq.selenium:selenium-java:2.48.2') {
-        exclude(module: 'selenium-htmlunit-driver')
+    compile rootProject.ext.junit
+    // see deps to exclude by visiting:
+    // https://bintray.com/bintray/jcenter/org.seleniumhq.selenium%3Aselenium-java/2.48.2/view#files
+    compile("org.seleniumhq.selenium:selenium-java:$rootProject.ext.selenium_version") {
         exclude(module: 'selenium-chrome-driver')
+        exclude(module: 'selenium-edge-driver')
+        exclude(module: 'selenium-htmlunit-driver')
         exclude(module: 'selenium-firefox-driver')
         exclude(module: 'selenium-ie-driver')
-        exclude(module: 'selenium-iphone-driver')
         exclude(module: 'selenium-safari-driver')
+        // exclude(module: 'selenium-support')
+        exclude(module: 'webbit')
+        exclude(module: 'selenium-leg-rc')
     }
 }

--- a/selendroid-grid-plugin/build.gradle
+++ b/selendroid-grid-plugin/build.gradle
@@ -1,5 +1,17 @@
 apply plugin: 'java'
 
 dependencies {
-    compile 'org.seleniumhq.selenium:selenium-server:2.48.2'
+    // see deps to exclude by visiting:
+    // https://bintray.com/bintray/jcenter/org.seleniumhq.selenium%3Aselenium-java/2.48.2/view#files
+    compile("org.seleniumhq.selenium:selenium-java:$rootProject.ext.selenium_version") {
+        exclude(module: 'selenium-chrome-driver')
+        exclude(module: 'selenium-edge-driver')
+        exclude(module: 'selenium-htmlunit-driver')
+        exclude(module: 'selenium-firefox-driver')
+        exclude(module: 'selenium-ie-driver')
+        exclude(module: 'selenium-safari-driver')
+        // exclude(module: 'selenium-support')
+        exclude(module: 'webbit')
+        exclude(module: 'selenium-leg-rc')
+    }
 }

--- a/selendroid-server-common/build.gradle
+++ b/selendroid-server-common/build.gradle
@@ -3,5 +3,5 @@ apply plugin: 'java'
 dependencies {
     compile 'org.json:json:20090211'
     compile 'io.netty:netty-all:4.0.21.Final'
-    testCompile 'junit:junit:4.12'
+    testCompile rootProject.ext.junit
 }

--- a/selendroid-server/build.gradle
+++ b/selendroid-server/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.4.0-beta5'
+        classpath rootProject.ext.android_build_tools_gradle
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
     }
 }
@@ -12,8 +12,8 @@ apply plugin: 'android-sdk-manager'
 apply plugin: 'android'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 10
@@ -63,9 +63,9 @@ sourceSets {
 dependencies {
     compile project(':selendroid-server-common')
     compile 'org.json:json:20090211'
-    compile 'com.android.support:support-v4:23.0.1'
+    compile 'com.android.support:support-v4:23.1.0'
     testCompile 'org.json:json:20090211'
-    testCompile 'junit:junit:4.12'
+    testCompile rootProject.ext.junit
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'commons-io:commons-io:2.2'
     testCompile 'org.apache.httpcomponents:httpclient:4.2.1'

--- a/selendroid-standalone/build.gradle
+++ b/selendroid-standalone/build.gradle
@@ -13,10 +13,20 @@ dependencies {
     compile 'com.android.tools.ddms:ddmlib:23.0.1'
     compile 'com.google.guava:guava:17.0'
     compile 'org.apache.commons:commons-lang3:3.1'
-    compile('org.seleniumhq.selenium:selenium-java:2.47.2') {
+    // see deps to exclude by visiting:
+    // https://bintray.com/bintray/jcenter/org.seleniumhq.selenium%3Aselenium-java/2.48.2/view#files
+    compile("org.seleniumhq.selenium:selenium-java:$rootProject.ext.selenium_version") {
+        exclude(module: 'selenium-chrome-driver')
+        exclude(module: 'selenium-edge-driver')
         exclude(module: 'selenium-htmlunit-driver')
+        exclude(module: 'selenium-firefox-driver')
+        exclude(module: 'selenium-ie-driver')
+        exclude(module: 'selenium-safari-driver')
+        // exclude(module: 'selenium-support')
+        exclude(module: 'webbit')
+        exclude(module: 'selenium-leg-rc')
     }
-    testCompile 'junit:junit:4.12'
+    testCompile rootProject.ext.junit
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
 }

--- a/selendroid-test-app/build.gradle
+++ b/selendroid-test-app/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.4.0-beta5'
+        classpath rootProject.ext.android_build_tools_gradle
     }
 }
 
@@ -14,10 +14,10 @@ repositories {
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile 'com.android.support:support-v4:23.0.1'
+    compile 'com.android.support:support-v4:23.1.0'
     testCompile project(':selendroid-client')
     testCompile project(':selendroid-standalone')
-    testCompile 'junit:junit:4.12'
+    testCompile rootProject.ext.junit
     testCompile 'net.sf.saxon:Saxon-HE:9.4.0.6'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     testCompile 'org.mockito:mockito-all:1.9.5'
@@ -27,8 +27,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 10

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,8 @@
+// must override project name to 'droiddriver'. otherwise the root folder name will
+// be used in jcenter and that could be named anything.
+// see http://gradle.org/docs/current/userguide/maven_plugin.html
+rootProject.name = 'selendroid'
+
 include 'android-driver'
 include 'selendroid-client'
 include 'selendroid-common'


### PR DESCRIPTION
- Use [ext](http://tools.android.com/tech-docs/new-build-system/tips) to define versions so we're consistent
- Properly exclude unused selenium dependencies
- Correctly set root project name via top level settings.gradle instead of defaulting to the folder name
